### PR TITLE
Update commandapi-bukkit-shade dependency to version 10.1.0 for 1.21.…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
         exclude("org.slf4j")
     }
 
-    shadow("dev.jorel:commandapi-bukkit-shade:10.0.1")
+    shadow("dev.jorel:commandapi-bukkit-shade:10.1.0")
 
     shadow(platform("net.kyori:adventure-bom:4.17.0"))
     shadow("net.kyori:adventure-api")


### PR DESCRIPTION
…6 support